### PR TITLE
Update PECompact sig for v3.02.2

### DIFF
--- a/db/PE/PECompact.2.sg
+++ b/db/PE/PECompact.2.sg
@@ -1,6 +1,6 @@
 // DIE's signature file
 
-init("packer","PeCompact");
+init("packer","PECompact");
 
 function detect(bShowType,bShowVersion,bShowOptions)
 {
@@ -32,6 +32,11 @@ function detect(bShowType,bShowVersion,bShowOptions)
     else if(PE.compareEP("B8........80002840"))
     {
         sVersion="2.x beta version";
+        bDetected=1;
+    }
+    else if(PE.compareEP("B8........5064FF35000000006489250000000033C08908'PECompact2'00"))
+    {
+        sVersion="3.02.2 or 3.03.21 beta";
         bDetected=1;
     }
     else if(PE.compareEP("B8........5064FF..........6489..........33C08908'PECo'"))


### PR DESCRIPTION
I've updated the PECompact signature to correctly detect the latest version 3.02.2.