### PR TITLE
Better heuristic for MSVC linker detection

### DIFF
--- a/db/PE/linker.6.sg
+++ b/db/PE/linker.6.sg
@@ -147,7 +147,7 @@ function detect(bShowType,bShowVersion,bShowOptions)
     // Correct version
     if(sName=="Microsoft Linker")
     {
-        if((PE.getMajorLinkerVersion()>15)||(PE.getMajorLinkerVersion()<3))
+        if(PE.isRichSignaturePresent())
         {
             var sMSLinkerVersion=getMSLinkerVersionFromRichSignature();
             if(sMSLinkerVersion!="")
@@ -156,7 +156,24 @@ function detect(bShowType,bShowVersion,bShowOptions)
             }
             else
             {
-                 sVersion+="*";
+                // Heuristic based on: https://en.wikipedia.org/wiki/Microsoft_Visual_C%2B%2B
+                if(nMajor == 14)
+                {
+                    switch(nMinor)
+                    {
+                        case 0: sVersion+=", Visual Studio 2015 14.0"; break;
+                        case 1: sVersion+=", Visual Studio 2017 15.0"; break;
+                        case 11: sVersion+=", Visual Studio 2017 15.3"; break;
+                        case 12: sVersion+=", Visual Studio 2017 15.5"; break;
+                        case 13: sVersion+=", Visual Studio 2017 15.6"; break;
+                        case 14: sVersion+=", Visual Studio 2017 15.7"; break;
+                        case 15: sVersion+=", Visual Studio 2017 15.8"; break;
+                        case 16: sVersion+=", Visual Studio 2017 15.9"; break;
+                        case 2: sVersion+=", Visual Studio 2019 16.0"; break;
+                        default: sVersion+="*"; break;
+                    }
+                }
+                sVersion+="*";
             }
         }
     }


### PR DESCRIPTION
Allow easier identification of Visual Studio version used to link the executable (fallback if no version can be determined from the rich header, but the rich header is present):

![](https://i.imgur.com/O77NsC0.png)