### PR TITLE
Fix bero and yodas rules

### DIFF
--- a/db/PE/BeRo.2.sg
+++ b/db/PE/BeRo.2.sg
@@ -28,6 +28,24 @@ function detect(bShowType,bShowVersion,bShowOptions)
         sVersion="1.00";
         bDetected=1;
     }
+    else if(PE.compareEP("6068........68......0068........e8..040000..................00"))
+    {
+        sVersion="1.00";
+        sOptions="LZMA";
+        bDetected=1;
+    }
+    else if(PE.compareEP("60e8000000005e81c6....0000bf........6081ec0804000089e357fc31c0b4"))
+    {
+        sVersion="1.00";
+        sOptions="CTX1";
+        bDetected=1;
+    }
+    else if(PE.compareEP("60c8940c0060fcbe........ad8945fc33c0f7d08945f8f7d0b408b923030000"))
+    {
+        sVersion="1.00";
+        sOptions="LZBRA";
+        bDetected=1;
+    }
 
     return result(bShowType,bShowVersion,bShowOptions);
 }

--- a/db/PE/Yodas Crypter.2.sg
+++ b/db/PE/Yodas Crypter.2.sg
@@ -32,19 +32,9 @@ function detect(bShowType,bShowVersion,bShowOptions)
             bDetected=1;
         }
     }
-    else if(PE.compareEP("558BEC535657E8$$$$$$$$E8$$$$$$$$33C064FF30648920CCC3"))
-    {
-        sVersion="1.01";
-        bDetected=1;
-    }
     else if(PE.compareEP("558BEC81ECC00000005356578DBD40FFFFFFB930000000B8CCCCCCCCF3AB60"))
     {
         sVersion="1.3";
-        bDetected=1;
-    }
-    else if(PE.compareEP("E8$$$$$$$$BB........E8$$$$$$$$E8$$$$$$$$33c064ff306489204bccc3"))
-    {
-        sVersion="1.02-1.03";
         bDetected=1;
     }
 

--- a/db/PE/Yodas Protector.2.sg
+++ b/db/PE/Yodas Protector.2.sg
@@ -1,0 +1,19 @@
+// DIE's signature file
+
+init("protector","Yoda's Protector");
+
+function detect(bShowType,bShowVersion,bShowOptions)
+{
+    if(PE.compareEP("558BEC535657E8$$$$$$$$E8$$$$$$$$33C064FF30648920CCC3"))
+    {
+        sVersion="1.01";
+        bDetected=1;
+    }
+    else if(PE.compareEP("E8$$$$$$$$BB........E8$$$$$$$$E8$$$$$$$$33c064ff306489204bccc3"))
+    {
+        sVersion="1.02-1.03";
+        bDetected=1;
+    }
+
+    return result(bShowType,bShowVersion,bShowOptions);
+}


### PR DESCRIPTION
I've improved the detection for PE binaries packed by BeRoEXEPacker and Yoda's Protector.