### PR TITLE
WAV duration correction

### DIFF
--- a/db/Binary/wav.1.sg
+++ b/db/Binary/wav.1.sg
@@ -47,7 +47,7 @@ function detect(bShowType,bShowVersion,bShowOptions)
                     var nOffset=Binary.findString(0x24,128,"data");
                     if(nOffset!=-1)
                     {
-                        var nSeconds=Binary.readDword(nOffset+4)/(nBPS/8)/nRate;
+                        var nSeconds=Binary.readDword(nOffset+4)/(nBPS/8)/nRate/nChannels;
                         sOptions=sOptions.append(duration(nSeconds));
                     }
                 }


### PR DESCRIPTION
Hi,

the duration calculation of WAV files only worked for mono files. For stereo files the duration was twice as long because the script doesn't divide through channel count.