### PR TITLE
Add generic Go compiler detection

### DIFF
--- a/db/PE/Go.4.sg
+++ b/db/PE/Go.4.sg
@@ -65,6 +65,10 @@ function detect(bShowType,bShowVersion,bShowOptions)
     {
         sVersion="1.x";
     }
+    else if (PE.isSignatureInSectionPresent(0, "ff20'Go build ID: '"))
+    {
+        sVersion=">= 1.15.0";
+    }
     else {
         bDetected=0;
     }


### PR DESCRIPTION
Add generic signature check in .text section so newer Go executables aren't shown as unknown.