### PR TITLE
Update Safengine signature

### DIFF
--- a/db/PE/Safengine Shielden.2.sg
+++ b/db/PE/Safengine Shielden.2.sg
@@ -21,8 +21,6 @@ function detect(bShowType,bShowVersion,bShowOptions)
         }
     }
     if(PE.compareEP("EB$$E9$$$$$$$$E8........'Safengine Shielden'"))
-    }
-    if(PE.compareEP("EB$$E9$$$$$$$$E8........'Safengine Shielden'"))
     {
         sVersion="2.X";
         bDetected=1;

--- a/db/PE/Safengine Shielden.2.sg
+++ b/db/PE/Safengine Shielden.2.sg
@@ -13,6 +13,14 @@ function detect(bShowType,bShowVersion,bShowOptions)
             sVersion="2.X";
             bDetected=1;
         }
+        if(PE.section[PE.nLastSection].FileSize==0x2000
+         &&PE.section[PE.nLastSection].VirtualSize==0x2000)
+        {
+            sVersion="";
+            bDetected=1;
+        }
+    }
+    if(PE.compareEP("EB$$E9$$$$$$$$E8........'Safengine Shielden'"))
     }
     if(PE.compareEP("EB$$E9$$$$$$$$E8........'Safengine Shielden'"))
     {


### PR DESCRIPTION
Hi @horsicq! I found a few binaries protected by Safengine. The last section has both virtual and raw size set to 0x2000 instead of 0x1000. I don't know if that's v2.X so I've used an empty `sVersion` string.

Thanks!