### PR TITLE
Fix for false Denuvo detection

### DIFF
--- a/db/PE/_denuvoComplete.2.sg
+++ b/db/PE/_denuvoComplete.2.sg
@@ -5,7 +5,7 @@ init("protector","Denuvo");
 
 function detect(bShowType,bShowVersion,bShowOptions)
 {
-    if (PE.isSectionNamePresent(".arch") || PE.isSectionNamePresent(".srdata") || PE.findString(0,1024,"Denuvo Timing"))
+    if (PE.isSectionNamePresent(".arch") || PE.isSectionNamePresent(".srdata") || PE.findString(0,1024,"Denuvo Timing")!=-1)
     {
       if(PE.isPEPlus())
       {


### PR DESCRIPTION
PE.findString() returns -1 if string is not found.
Causing if statement to evaluate to -1 instead of false then continue with next if statement.
Fixes #95 