### PR TITLE
Improve ELF files compiler detection

### DIFF
--- a/db/ELF/Free Pascal.4.sg
+++ b/db/ELF/Free Pascal.4.sg
@@ -20,6 +20,22 @@ function detect(bShowType,bShowVersion,bShowOptions)
     {
         bDetected=1;
     }
+    else if(ELF.isSectionNamePresent(".fpcdata"))
+    {
+        bDetected=1;
+        var nSection=ELF.getSectionNumber(".fpcdata");
+        var nOffset=ELF.getSectionFileOffset(nSection);
+        var nSize=ELF.getSectionFileSize(nSection);
+        
+        if(nSize>0)
+        {
+            var nStringOffset=ELF.findString(nOffset,4,"FPC ");
+            if(nStringOffset!=-1)
+            {
+                sVersion=ELF.getString(nStringOffset+4);
+            }
+        }
+    }
     else if(ELF.isSectionNamePresent(".data"))
     {
         var nSection=ELF.getSectionNumber(".data");

--- a/db/ELF/Go.4.sg
+++ b/db/ELF/Go.4.sg
@@ -1,0 +1,185 @@
+// DIE's signature file
+// Author: fernandom - menteb.in
+
+init("compiler","Go");
+
+function detect(bShowType,bShowVersion,bShowOptions)
+{
+    if (ELF.isSectionNamePresent(".gosymtab") ||
+        ELF.isSectionNamePresent(".gopclntab") ||
+        ELF.isSectionNamePresent(".go.buildinfo") ||
+        ELF.isSectionNamePresent(".note.go.buildid"))
+    {
+        bDetected=1;
+    }
+
+    // amd64
+    if (ELF.compareEP("488d742408488b3c24b810174200ffe0b870f94100ffe0000000000000000000"))
+    {
+        bDetected=1;
+        sVersion="1.2.2";
+    }
+    else if (ELF.compareEP("488d742408488b3c24b8907f4200ffe0b800564200ffe0000000000000000000"))
+    {
+        bDetected=1;
+        sVersion="1.3 or 1.3.1";
+    }
+    else if (ELF.compareEP("488d742408488b3c24b8c07f4200ffe0b830564200ffe0000000000000000000"))
+    {
+        bDetected=1;
+        sVersion="1.3.2";
+    }
+    else if (ELF.compareEP("488d742408488b3c24b8e07f4200ffe0b850564200ffe0000000000000000000"))
+    {
+        bDetected=1;
+        sVersion="1.3.3";
+    }
+    else if (ELF.compareEP("488d742408488b3c24488d0510000000ffe00000000000000000000000000000"))
+    {
+        bDetected=1;
+        sVersion="1.4.x or 1.5.x";
+    }
+    else if (ELF.compareEP("488d742408488b3c24488d0510000000ffe0cccccccccccccccccccccccccccc"))
+    {
+        bDetected=1;
+        sVersion="1.6.x-1.9.x";
+    }
+    else if (ELF.compareEP("e92bc9ffffcccccccccccccccccccccc8b7c2408b8e70000000f05c3cccccccc"))
+    {
+        bDetected=1;
+        sVersion="1.10.x";
+    }
+    else if (ELF.compareEP("e9cbc6ffffcccccccccccccccccccccc8b7c2408b8e70000000f05c3cccccccc"))
+    {
+        bDetected=1;
+        sVersion="1.11.x";
+    }
+    else if (ELF.compareEP("e9dbc6ffffcccccccccccccccccccccc8b7c2408b8e70000000f05c3cccccccc"))
+    {
+        bDetected=1;
+        sVersion="1.12.x";
+    }
+    else if (ELF.compareEP("e92bc6ffffcccccccccccccccccccccc8b7c2408b8e70000000f05c3cccccccc"))
+    {
+        bDetected=1;
+        sVersion="1.13.x";
+    }
+    else if (ELF.compareEP("e92bc4ffffcccccccccccccccccccccc8b7c2408b8e70000000f05c3cccccccc"))
+    {
+        bDetected=1;
+        sVersion="1.14.x";
+    }
+    else if (ELF.compareEP("e91bcbffffcccccccccccccccccccccccccccccccccccccccccccccccccccccc"))
+    {
+        bDetected=1;
+        sVersion="1.15.x";
+    }
+    else if (ELF.compareEP("e95bcaffffcccccccccccccccccccccccccccccccccccccccccccccccccccccc"))
+    {
+        bDetected=1;
+        sVersion="1.16.x";
+    }
+    else if (ELF.compareEP("e93bc6ffffcccccccccccccccccccccccccccccccccccccccccccccccccccccc"))
+    {
+        bDetected=1;
+        sVersion="1.17.x";
+    }
+    
+    // 386
+    else if (ELF.compareEP("83ec088b4424088d5c240c890424895c2404e87902ffffe804000000cd030000"))
+    {
+        bDetected=1;
+        sVersion="1.2.2";
+    }
+    else if (ELF.compareEP("83ec088b4424088d5c240c890424895c2404e8f977feffe804000000cd030000"))
+    {
+        bDetected=1;
+        sVersion="1.3 or 1.3.1";
+    }
+    else if (ELF.compareEP("83ec088b4424088d5c240c890424895c2404e8e977feffe804000000cd030000"))
+    {
+        bDetected=1;
+        sVersion="1.3.2";
+    }
+    else if (ELF.compareEP("83ec088b4424088d5c240c890424895c2404e8c977feffe804000000cd030000"))
+    {
+        bDetected=1;
+        sVersion="1.3.3";
+    }
+    else if (ELF.compareEP("83ec088b4424088d5c240c890424895c2404e89932ffffe804000000cd030000"))
+    {
+        bDetected=1;
+        sVersion="1.4.x";
+    }
+    else if (ELF.compareEP("83ec088b4424088d5c240c890424895c2404e809000000cd0300000000000000"))
+    {
+        bDetected=1;
+        sVersion="1.5.x";
+    }
+    else if (ELF.compareEP("83ec088b4424088d5c240c890424895c2404e809000000cd03cccccccccccccc"))
+    {
+        bDetected=1;
+        sVersion="1.6.x-1.9.x";
+    }
+    //e92bd8ffffccccccccccccccccccccccb8fc0000008b5c2404cd80cd03c3cccc
+    else if (ELF.compareEP("e9....ffffccccccccccccccccccccccb8fc0000008b5c2404cd80cd03c3cccc"))
+    {
+        bDetected=1;
+        sVersion="1.10";
+    }
+    else if (ELF.compareEP("e9ebd8ffffccccccccccccccccccccccb8fc0000008b5c2404cd80cd03c3cccc"))
+    {
+        bDetected=1;
+        sVersion="1.10.x";
+    }
+    else if (ELF.compareEP("e96bdbffffccccccccccccccccccccccb8fc0000008b5c2404cd80cd03c3cccc"))
+    {
+        bDetected=1;
+        sVersion="1.11.x";
+    }
+    else if (ELF.compareEP("e97b..ffffccccccccccccccccccccccb8fc0000008b5c2404cd80cd03c3cccc"))
+    {
+        bDetected=1;
+        sVersion="1.12.x";
+    }
+    else if (ELF.compareEP("e99bffffccccccccccccccccccccccb8fc0000008b5c2404cd80cd03c3cccc"))
+    {
+        bDetected=1;
+        sVersion="1.13.x";
+    }
+    else if (ELF.compareEP("e99bd9ffffccccccccccccccccccccccb8fc0000008b5c2404cd80cd03c3cccc"))
+    {
+        bDetected=1;
+        sVersion="1.14.x";
+    }
+    else if (ELF.compareEP("e9abdcffffccccccccccccccccccccccb8010000008b5c2404cd80cd03c3cccc"))
+    {
+        bDetected=1;
+        sVersion="1.15.x";
+    }
+    else if (ELF.compareEP("e9dbdcffffccccccccccccccccccccccb8010000008b5c2404cd80cd03c3cccc"))
+    {
+        bDetected=1;
+        sVersion="1.16.x";
+    }
+    else if (ELF.compareEP("e92bdeffffccccccccccccccccccccccb8010000008b5c2404cd80cd03c3cccc"))
+    {
+        bDetected=1;
+        sVersion="1.17.x";
+    }
+
+    // generic rule for amd64 and 386
+    else if (ELF.compareEP("e9....ffff..................................................cccc"))
+    {
+        bDetected=1;
+        sVersion="1.10.x-1.17.x";
+    }
+    
+    // arm
+    else if (ELF.compareEP("00009de504108de204409fe500f084e2feffffea"))
+    {
+        bDetected=1;
+    }
+    
+    return result(bShowType,bShowVersion,bShowOptions);
+}

--- a/db/ELF/Rust.4.sg
+++ b/db/ELF/Rust.4.sg
@@ -1,0 +1,26 @@
+// DIE's signature file
+// Author: fernandom - menteb.in
+
+init("compiler","Rust");
+
+function detect(bShowType,bShowVersion,bShowOptions)
+{
+    if (ELF.isStringInTablePresent(".strtab","rust_panic"))
+    {
+        bDetected=1;
+        var nSection=ELF.getSectionNumber(".debug_str");
+        var nOffset=ELF.getSectionFileOffset(nSection);
+        var nSize=ELF.getSectionFileSize(nSection);
+        
+        if(nSize>0)
+        {
+            var nStringOffset=ELF.findString(nOffset,6,"rustc ");
+            if(nStringOffset!=-1)
+            {
+                sVersion=ELF.getString(nStringOffset);
+            }
+        }
+    }
+
+    return result(bShowType,bShowVersion,bShowOptions);
+}


### PR DESCRIPTION
Hi there! This PR improves the compiler detection for ELF files:

- Go compiled files based (both symbol and EP-based).
- Rust (symbol-based).
- Improved Free Pascal (recognize `.fpcdata` section too).

Thanks for this great tool! 🙌