### PR TITLE
Recotegorize some of the rules

### DIFF
--- a/db/COM/Anti-Lamer Cryptor.2.sg
+++ b/db/COM/Anti-Lamer Cryptor.2.sg
@@ -1,7 +1,7 @@
 // DIE's signature file
 // Author: hypn0 <hypn0@mail.ru>
 
-init("protector","Anti-Lamer Cryptor");
+init("crypter","Anti-Lamer Cryptor");
 
 function detect(bShowType,bShowVersion,bShowOptions)
 {

--- a/db/COM/Deep Crypter.2.sg
+++ b/db/COM/Deep Crypter.2.sg
@@ -1,7 +1,7 @@
 // DIE's signature file
 // Author: hypn0 <hypn0@mail.ru>
 
-init("protector","Deep Crypter");
+init("crypter","Deep Crypter");
 
 function detect(bShowType,bShowVersion,bShowOptions)
 {

--- a/db/COM/J0B cryptor.2.sg
+++ b/db/COM/J0B cryptor.2.sg
@@ -1,7 +1,7 @@
 // DIE's signature file
 // Author: hypn0 <hypn0@mail.ru>
 
-init("protector","J0B cryptor");
+init("crypter","J0B cryptor");
 
 function detect(bShowType,bShowVersion,bShowOptions)
 {

--- a/db/COM/PU-Cryptor.2.sg
+++ b/db/COM/PU-Cryptor.2.sg
@@ -1,7 +1,7 @@
 // DIE's signature file
 // Author: hypn0 <hypn0@mail.ru>
 
-init("protector","PU-Cryptor");
+init("crypter","PU-Cryptor");
 
 function detect(bShowType,bShowVersion,bShowOptions)
 {

--- a/db/COM/Phrozen Crew cryptor.2.sg
+++ b/db/COM/Phrozen Crew cryptor.2.sg
@@ -1,7 +1,7 @@
 // DIE's signature file
 // Author: hypn0 <hypn0@mail.ru>
 
-init("protector","Phrozen Crew cryptor");
+init("crypter","Phrozen Crew cryptor");
 
 function detect(bShowType,bShowVersion,bShowOptions)
 {

--- a/db/COM/SDW.2.sg
+++ b/db/COM/SDW.2.sg
@@ -1,7 +1,7 @@
 // DIE's signature file
 // Author: hypn0 <hypn0@mail.ru>
 
-init("protector","Shadow Com Cryptor (SDW)");
+init("crypter","Shadow Com Cryptor (SDW)");
 
 function detect(bShowType,bShowVersion,bShowOptions)
 {

--- a/db/COM/Shadow COM encryptor.2.sg
+++ b/db/COM/Shadow COM encryptor.2.sg
@@ -1,7 +1,7 @@
 // DIE's signature file
 // Author: hypn0 <hypn0@mail.ru>
 
-init("protector","Shadow COM encryptor");
+init("crypter","Shadow COM encryptor");
 
 function detect(bShowType,bShowVersion,bShowOptions)
 {

--- a/db/COM/Sydex.2.sg
+++ b/db/COM/Sydex.2.sg
@@ -1,7 +1,7 @@
 // DIE's signature file
 // Author: hypn0 <hypn0@mail.ru>
 
-init("protector","Sydex cryptor");
+init("crypter","Sydex cryptor");
 
 function detect(bShowType,bShowVersion,bShowOptions)
 {

--- a/db/COM/USCC.2.sg
+++ b/db/COM/USCC.2.sg
@@ -1,7 +1,7 @@
 // DIE's signature file
 // Author: hypn0 <hypn0@mail.ru>
 
-init("protector","Shitty COM Cryptor");
+init("crypter","Shitty COM Cryptor");
 
 function detect(bShowType,bShowVersion,bShowOptions)
 {

--- a/db/COM/Unknown cryptors.2.sg
+++ b/db/COM/Unknown cryptors.2.sg
@@ -1,7 +1,7 @@
 // DIE's signature file
 // Author: hypn0 <hypn0@mail.ru>
 
-init("protector","Unknown cryptor");
+init("crypter","Unknown cryptor");
 
 function detect(bShowType,bShowVersion,bShowOptions)
 {

--- a/db/COM/WiZ Cryptor.2.sg
+++ b/db/COM/WiZ Cryptor.2.sg
@@ -1,7 +1,7 @@
 // DIE's signature file
 // Author: hypn0 <hypn0@mail.ru>
 
-init("protector","WiZ Cryptor");
+init("crypter","WiZ Cryptor");
 
 function detect(bShowType,bShowVersion,bShowOptions)
 {

--- a/db/COM/cryptors.2.sg
+++ b/db/COM/cryptors.2.sg
@@ -1,7 +1,7 @@
 // DIE's signature file
 // Author: hypn0 <hypn0@mail.ru>
 
-init("protector","Cryptor");
+init("crypter","Cryptor");
 
 function detect(bShowType,bShowVersion,bShowOptions)
 {

--- a/db/MSDOS/Crypt (Dismember).2.sg
+++ b/db/MSDOS/Crypt (Dismember).2.sg
@@ -1,7 +1,7 @@
 // DIE's signature file
 // Author: hypn0 <hypn0@mail.ru>
 
-init("protector","Cryptor by Dismember");
+init("crypter","Cryptor by Dismember");
 
 function detect(bShowType,bShowVersion,bShowOptions)
 {

--- a/db/MSDOS/Cryptors.2.sg
+++ b/db/MSDOS/Cryptors.2.sg
@@ -1,7 +1,7 @@
 // DIE's signature file
 // Author: hypn0 <hypn0@mail.ru>
 
-init("protector","Cryptor");
+init("crypter","Cryptor");
 
 function detect(bShowType,bShowVersion,bShowOptions)
 {

--- a/db/MSDOS/EXE-Cryptor.2.sg
+++ b/db/MSDOS/EXE-Cryptor.2.sg
@@ -1,7 +1,7 @@
 // DIE's signature file
 // Author: hypn0 <hypn0@mail.ru>
 
-init("protector","EXE-Cryptor");
+init("crypter","EXE-Cryptor");
 
 function detect(bShowType,bShowVersion,bShowOptions)
 {

--- a/db/MSDOS/TUCCRYP.2.sg
+++ b/db/MSDOS/TUCCRYP.2.sg
@@ -1,7 +1,7 @@
 // DIE's signature file
 // Author: hypn0 <hypn0@mail.ru>
 
-init("cryptor","TUCCRYP");
+init("crypter","TUCCRYP");
 
 function detect(bShowType,bShowVersion,bShowOptions)
 {

--- a/db/MSDOS/Unknown cryptors.2.sg
+++ b/db/MSDOS/Unknown cryptors.2.sg
@@ -1,7 +1,7 @@
 // DIE's signature file
 // Author: hypn0 <hypn0@mail.ru>
 
-init("protector","Unknown cryptor");
+init("crypter","Unknown cryptor");
 
 function detect(bShowType,bShowVersion,bShowOptions)
 {

--- a/db/MSDOS/deep-CRyPTer.2.sg
+++ b/db/MSDOS/deep-CRyPTer.2.sg
@@ -1,6 +1,6 @@
 // DIE's signature file
 
-init("protector","deep-CRyPTer");
+init("crypter","deep-CRyPTer");
 
 function detect(bShowType,bShowVersion,bShowOptions)
 {

--- a/db/PE/3dcrypter.1.sg
+++ b/db/PE/3dcrypter.1.sg
@@ -1,6 +1,6 @@
 // DIE's signature file
 
-init("Crypter","3dCrypter");
+init("crypter","3dCrypter");
 
 function detect(bShowType,bShowVersion,bShowOptions)
 {

--- a/db/PE/ABC Cryptor.2.sg
+++ b/db/PE/ABC Cryptor.2.sg
@@ -1,6 +1,6 @@
 // DIE's signature file
 
-init("protector","ABC Cryptor");
+init("crypter","ABC Cryptor");
 
 function detect(bShowType,bShowVersion,bShowOptions)
 {

--- a/db/PE/Aase Crypter.2.sg
+++ b/db/PE/Aase Crypter.2.sg
@@ -1,6 +1,6 @@
 // DIE's signature file
 
-init("protector","Aase Crypter");
+init("crypter","Aase Crypter");
 
 function detect(bShowType,bShowVersion,bShowOptions)
 {

--- a/db/PE/AlmafuerteCrypter.1.sg
+++ b/db/PE/AlmafuerteCrypter.1.sg
@@ -1,7 +1,7 @@
 
 // DIE's signature file
 
-init("Crypter","AlmafuerteCrypter");
+init("crypter","AlmafuerteCrypter");
 
 function detect(bShowType,bShowVersion,bShowOptions)
 {

--- a/db/PE/Anslym Crypter.2.sg
+++ b/db/PE/Anslym Crypter.2.sg
@@ -1,6 +1,6 @@
 // DIE's signature file
 
-init("protector","Anslym Crypter");
+init("crypter","Anslym Crypter");
 
 function detect(bShowType,bShowVersion,bShowOptions)
 {

--- a/db/PE/App Encryptor.2.sg
+++ b/db/PE/App Encryptor.2.sg
@@ -1,6 +1,6 @@
 // DIE's signature file
 
-init("protector","App Encryptor");
+init("crypter","App Encryptor");
 
 function detect(bShowType,bShowVersion,bShowOptions)
 {

--- a/db/PE/AverCryptor.2.sg
+++ b/db/PE/AverCryptor.2.sg
@@ -1,6 +1,6 @@
 // DIE's signature file
 
-init("protector","AverCryptor");
+init("crypter","AverCryptor");
 
 function detect(bShowType,bShowVersion,bShowOptions)
 {

--- a/db/PE/BattleshipCrypter.2.sg
+++ b/db/PE/BattleshipCrypter.2.sg
@@ -1,6 +1,6 @@
 // Author A.S.L
 
-init("Crypter","Battleship Crypter");
+init("crypter","Battleship Crypter");
 
 function detect(bShowType,bShowVersion,bShowOptions)
 {

--- a/db/PE/ChainskiCrypter.1.sg
+++ b/db/PE/ChainskiCrypter.1.sg
@@ -1,6 +1,6 @@
 // DIE's signature file
 
-init("Crypter","ChainskiCrypter");
+init("crypter","ChainskiCrypter");
 
 function detect(bShowType,bShowVersion,bShowOptions)
 {

--- a/db/PE/CodeCrypter.2.sg
+++ b/db/PE/CodeCrypter.2.sg
@@ -1,6 +1,6 @@
 // DIE's signature file
 
-init("protector","CodeCrypter");
+init("crypter","CodeCrypter");
 
 function detect(bShowType,bShowVersion,bShowOptions)
 {

--- a/db/PE/Crypter.2.sg
+++ b/db/PE/Crypter.2.sg
@@ -1,6 +1,6 @@
 // DIE's signature file
 
-init("protector","Crypter");
+init("crypter","Crypter");
 
 function detect(bShowType,bShowVersion,bShowOptions)
 {

--- a/db/PE/Duals eXe Encryptor.2.sg
+++ b/db/PE/Duals eXe Encryptor.2.sg
@@ -1,6 +1,6 @@
 // DIE's signature file
 
-init("protector","Duals eXe Encryptor");
+init("crypter","Duals eXe Encryptor");
 
 function detect(bShowType,bShowVersion,bShowOptions)
 {

--- a/db/PE/EXECryptor.2.sg
+++ b/db/PE/EXECryptor.2.sg
@@ -1,6 +1,6 @@
 // DIE's signature file
 
-init("protector","EXECryptor");
+init("crypter","EXECryptor");
 
 function detect(bShowType,bShowVersion,bShowOptions)
 {

--- a/db/PE/Fly-Crypter.2.sg
+++ b/db/PE/Fly-Crypter.2.sg
@@ -1,6 +1,6 @@
 // DIE's signature file
 
-init("protector","Fly-Crypter");
+init("crypter","Fly-Crypter");
 
 function detect(bShowType,bShowVersion,bShowOptions)
 {

--- a/db/PE/FreeCryptor.2.sg
+++ b/db/PE/FreeCryptor.2.sg
@@ -1,6 +1,6 @@
 // DIE's signature file
 
-init("protector","FreeCryptor");
+init("crypter","FreeCryptor");
 
 function detect(bShowType,bShowVersion,bShowOptions)
 {

--- a/db/PE/INCrypter.2.sg
+++ b/db/PE/INCrypter.2.sg
@@ -1,6 +1,6 @@
 // DIE's signature file
 
-init("protector","INCrypter");
+init("crypter","INCrypter");
 
 function detect(bShowType,bShowVersion,bShowOptions)
 {

--- a/db/PE/KCryptor.2.sg
+++ b/db/PE/KCryptor.2.sg
@@ -1,7 +1,7 @@
 // DIE's signature file
 // Author: hypn0 <hypn0@mail.ru>
 
-init("protector","K!Cryptor");
+init("crypter","K!Cryptor");
 
 function detect(bShowType,bShowVersion,bShowOptions)
 {

--- a/db/PE/NativeCryptor by DosX.2.sg
+++ b/db/PE/NativeCryptor by DosX.2.sg
@@ -1,6 +1,6 @@
 // DIE's signature file
 
-init("protector","NativeCryptor by DosX");
+init("crypter","NativeCryptor by DosX");
 
 function detect(bShowType,bShowVersion,bShowOptions)
 {

--- a/db/PE/Open Source Code Crypter.2.sg
+++ b/db/PE/Open Source Code Crypter.2.sg
@@ -1,6 +1,6 @@
 // DIE's signature file
 
-init("protector","Open Source Code Crypter");
+init("crypter","Open Source Code Crypter");
 
 function detect(bShowType,bShowVersion,bShowOptions)
 {

--- a/db/PE/RCryptor.2.sg
+++ b/db/PE/RCryptor.2.sg
@@ -1,6 +1,6 @@
 // DIE's signature file
 
-init("protector","RCryptor");
+init("crypter","RCryptor");
 
 function detect(bShowType,bShowVersion,bShowOptions)
 {

--- a/db/PE/RDG Tejon Crypter.2.sg
+++ b/db/PE/RDG Tejon Crypter.2.sg
@@ -1,4 +1,4 @@
-init("protector","RDG Tejon Crypter");
+init("crypter","RDG Tejon Crypter");
 
 function detect(bShowType,bShowVersion,bShowOptions)
 {

--- a/db/PE/Sexe Crypter.2.sg
+++ b/db/PE/Sexe Crypter.2.sg
@@ -1,6 +1,6 @@
 // DIE's signature file
 
-init("protector","Sexe Crypter");
+init("crypter","Sexe Crypter");
 
 function detect(bShowType,bShowVersion,bShowOptions)
 {

--- a/db/PE/Simple UPX Cryptor.2.sg
+++ b/db/PE/Simple UPX Cryptor.2.sg
@@ -1,6 +1,6 @@
 // DIE's signature file
 
-init("protector","Simple UPX Cryptor");
+init("crypter","Simple UPX Cryptor");
 
 function detect(bShowType,bShowVersion,bShowOptions)
 {

--- a/db/PE/Stones PE Encryptor.2.sg
+++ b/db/PE/Stones PE Encryptor.2.sg
@@ -1,6 +1,6 @@
 // DIE's signature file
 
-init("protector","Stone's PE Encryptor");
+init("crypter","Stone's PE Encryptor");
 
 function detect(bShowType,bShowVersion,bShowOptions)
 {

--- a/db/PE/The Best Cryptor.2.sg
+++ b/db/PE/The Best Cryptor.2.sg
@@ -1,7 +1,7 @@
 // DIE's signature file
 // Author: hypn0 <hypn0@mail.ru>
 
-init("protector","The Best Cryptor by FsK");
+init("crypter","The Best Cryptor by FsK");
 
 function detect(bShowType,bShowVersion,bShowOptions)
 {

--- a/db/PE/UPXcrypter.2.sg
+++ b/db/PE/UPXcrypter.2.sg
@@ -1,6 +1,6 @@
 // DIE's signature file
 
-init("protector","UPXcrypter");
+init("crypter","UPXcrypter");
 
 function detect(bShowType,bShowVersion,bShowOptions)
 {

--- a/db/PE/Yodas Crypter.2.sg
+++ b/db/PE/Yodas Crypter.2.sg
@@ -1,6 +1,6 @@
 // DIE's signature file
 
-init("protector","Yoda's Crypter");
+init("crypter","Yoda's Crypter");
 
 function detect(bShowType,bShowVersion,bShowOptions)
 {

--- a/db/PE/ass-crypter.2.sg
+++ b/db/PE/ass-crypter.2.sg
@@ -1,6 +1,6 @@
 // DIE's signature file
 
-init("protector","ass-crypter");
+init("crypter","ass-crypter");
 
 function detect(bShowType,bShowVersion,bShowOptions)
 {


### PR DESCRIPTION
Some of the rules had the category already in their name as "Crypter" or "Cryptor", but the actual categories were Protector & similar. Maybe the type "Crypter" didn't exist before, so I just unified their category as "Crypter".