### PR TITLE
Python fix python version newer than 3.9

### DIFF
--- a/db/PE/Python.3.sg
+++ b/db/PE/Python.3.sg
@@ -3,7 +3,7 @@
 init("library", "Python");
 
 function detect(bShowType, bShowVersion, bShowOptions) {
-    var aPython = PE.isLibraryPresentExp(/^python(\d\d)/i);
+    var aPython = PE.isLibraryPresentExp(/^python(\d+)/i);
     if (aPython) {
         sVersion = aPython[1] / 10;
         bDetected = true;


### PR DESCRIPTION
this patten 

>  PE.isLibraryPresentExp(/^python(\d\d)/i); 

 to test "python310.dll"  returns  

python310.dll, 31

followed  "sVersion = aPython[1] / 10;  " the sVersion to  3.1 

the new patten will fix it