### PR TITLE
fix python version newer than 3.9

### DIFF
--- a/db/PE/Python.3.sg
+++ b/db/PE/Python.3.sg
@@ -3,9 +3,9 @@
 init("library", "Python");
 
 function detect(bShowType, bShowVersion, bShowOptions) {
-    var aPython = PE.isLibraryPresentExp(/^python(\d+)/i);
+    var aPython = PE.isLibraryPresentExp(/^python(\d)(\d+)/i);
     if (aPython) {
-        sVersion = aPython[1] / 10;
+        sVersion = aPython[1] + "." + aPython[2];
         bDetected = true;
     }
 


### PR DESCRIPTION
var aPython = PE.isLibraryPresentExp(/^python(\d+)/i);   // 311

        sVersion = aPython[1] / 10;   // 31.1 wrong 
