### PR TITLE
change OSX to macOS in BUILD.md

### DIFF
--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -73,7 +73,7 @@ make -j4
 sudo make install
 ```
 
-# How to build on OSX
+# How to build on macOS
 
 Install Qt 5.15.2: https://github.com/horsicq/build_tools
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated heading in the documentation for clarity, changing "How to build on OSX" to "How to build on macOS."

<!-- end of auto-generated comment: release notes by coderabbit.ai -->