### PR TITLE
Improved GoLang handling

### DIFF
--- a/db/PE/Go.4.sg
+++ b/db/PE/Go.4.sg
@@ -6,48 +6,54 @@
 init("compiler", "Go");
 
 function detect(bShowType, bShowVersion, bShowOptions) {
-    // All go compiled PE binaries have a .symtab section
+    bDetected = false;
+
+    // All **UNMODIFIED** go compiled PE binaries have a .symtab section
     if (!PE.section[".symtab"]) {
-        bDetected = false;
-        return result(bShowType, bShowVersion);
+        // If it doesn't have, let's try a heuristic only, no pattern matching
+        // Who knows if pattern matching is good enough
+        if (PE.isSignatureInSectionPresent(0, "ff20'Go build ID: '")) {
+            sVersion = "1.15.0-X.XX.X";
+            bDetected = true;
+        }
     }
-
-    bDetected = 1;
-
-    if (PE.compareEP("488d742408488b3c24488d0510000000ffe0cccccccccccccccccccccccccccc") ||
-        PE.compareEP("83ec0c8b44240c8d5c241089442404895c2408c70424ffffffffe901000000cc")) {
-        sVersion = "1.7.x-1.9.x";
-    } else if (PE.compareEP("e90bd8ffffcccccccccccccccccccccc8b5c240464c705340000000000000089") ||
-        PE.compareEP("e92bc7ffffcccccccccccccccccccccc51488b01488b7110488b490865488b3c")) {
-        sVersion = "1.10";
-    } else if (PE.compareEP("e98bc8ffffcccccccccccccccccccccc51488b01488b7110488b490865488b3c") ||
-        PE.compareEP("e90bd9ffffcccccccccccccccccccccc8b5c240464c705340000000000000089")) {
-        sVersion = "1.10.x";
-    } else if (PE.compareEP("e98bdbffffcccccccccccccccccccccc8b5c240464c705340000000000000089") ||
-        PE.compareEP("e9dbc5ffffcccccccccccccccccccccc51488b01488b7110488b490865488b3c")) {
-        sVersion = "1.11-1.11.x";
-    } else if (PE.compareEP("e9ebc5ffffcccccccccccccccccccccc51488b01488b7110488b490865488b3c") ||
-        PE.compareEP("e99bdbffffcccccccccccccccccccccc8b5c240464c705340000000000000089")) {
-        sVersion = "1.12 or 1.12.2-1.12.9";
-    } else if (PE.compareEP("e98bc4ffffcccccccccccccccccccccc51488b01488b7110488b490865488b3c") ||
-        PE.compareEP("e99bdaffffcccccccccccccccccccccc8b5c240464c705340000000000000089")) {
-        sVersion = "1.12.1";
-    } else if (PE.compareEP("e92bc5ffffcccccccccccccccccccccc51488b01488b7110488b490865488b3c") ||
-        PE.compareEP("e9cbdaffffcccccccccccccccccccccc8b5c240464c705340000000000000089")) {
-        sVersion = "1.13 or 1.13.2";
-    } else if (PE.compareEP("e9cbc3ffffcccccccccccccccccccccc51488b01488b7110488b490865488b3c") ||
-        PE.compareEP("e9cbd9ffffcccccccccccccccccccccc8b5c240464c705340000000000000089")) {
-        sVersion = "1.13.1 or 1.13.3-9";
-    } else if (PE.compareEP("e9cbd8ffffcccccccccccccccccccccc8b5c240464c705340000000000000089") ||
-        PE.compareEP("e9cbc1ffffcccccccccccccccccccccc51488b01488b7110488b490865488b3c")) {
-        sVersion = "1.14 or 1.14.x";
-    } else if (PE.compareEP("e9....ffffcccccccccccccccccccccc51488b01488b7110488b490865488b3c2530000000c7476800000000") ||
-        PE.compareEP("e9....ffffcccccccccccccccccccccc8b5c240464c705340000000000000089e58b4b0489c8c1e00229c489e78b7308fcf3")) {
-        sVersion = "1.x";
-    } else if (PE.isSignatureInSectionPresent(0, "ff20'Go build ID: '")) {
-        sVersion = "1.15.0-X.XX.X";
-    } else {
-        bDetected = false;
+    else {
+        bDetected = true;
+        if (PE.compareEP("488d742408488b3c24488d0510000000ffe0cccccccccccccccccccccccccccc") ||
+            PE.compareEP("83ec0c8b44240c8d5c241089442404895c2408c70424ffffffffe901000000cc")) {
+            sVersion = "1.7.x-1.9.x";
+        } else if (PE.compareEP("e90bd8ffffcccccccccccccccccccccc8b5c240464c705340000000000000089") ||
+            PE.compareEP("e92bc7ffffcccccccccccccccccccccc51488b01488b7110488b490865488b3c")) {
+            sVersion = "1.10";
+        } else if (PE.compareEP("e98bc8ffffcccccccccccccccccccccc51488b01488b7110488b490865488b3c") ||
+            PE.compareEP("e90bd9ffffcccccccccccccccccccccc8b5c240464c705340000000000000089")) {
+            sVersion = "1.10.x";
+        } else if (PE.compareEP("e98bdbffffcccccccccccccccccccccc8b5c240464c705340000000000000089") ||
+            PE.compareEP("e9dbc5ffffcccccccccccccccccccccc51488b01488b7110488b490865488b3c")) {
+            sVersion = "1.11-1.11.x";
+        } else if (PE.compareEP("e9ebc5ffffcccccccccccccccccccccc51488b01488b7110488b490865488b3c") ||
+            PE.compareEP("e99bdbffffcccccccccccccccccccccc8b5c240464c705340000000000000089")) {
+            sVersion = "1.12 or 1.12.2-1.12.9";
+        } else if (PE.compareEP("e98bc4ffffcccccccccccccccccccccc51488b01488b7110488b490865488b3c") ||
+            PE.compareEP("e99bdaffffcccccccccccccccccccccc8b5c240464c705340000000000000089")) {
+            sVersion = "1.12.1";
+        } else if (PE.compareEP("e92bc5ffffcccccccccccccccccccccc51488b01488b7110488b490865488b3c") ||
+            PE.compareEP("e9cbdaffffcccccccccccccccccccccc8b5c240464c705340000000000000089")) {
+            sVersion = "1.13 or 1.13.2";
+        } else if (PE.compareEP("e9cbc3ffffcccccccccccccccccccccc51488b01488b7110488b490865488b3c") ||
+            PE.compareEP("e9cbd9ffffcccccccccccccccccccccc8b5c240464c705340000000000000089")) {
+            sVersion = "1.13.1 or 1.13.3-9";
+        } else if (PE.compareEP("e9cbd8ffffcccccccccccccccccccccc8b5c240464c705340000000000000089") ||
+            PE.compareEP("e9cbc1ffffcccccccccccccccccccccc51488b01488b7110488b490865488b3c")) {
+            sVersion = "1.14 or 1.14.x";
+        } else if (PE.compareEP("e9....ffffcccccccccccccccccccccc51488b01488b7110488b490865488b3c2530000000c7476800000000") ||
+            PE.compareEP("e9....ffffcccccccccccccccccccccc8b5c240464c705340000000000000089e58b4b0489c8c1e00229c489e78b7308fcf3")) {
+            sVersion = "1.x";
+        } else if (PE.isSignatureInSectionPresent(0, "ff20'Go build ID: '")) {
+            sVersion = "1.15.0-X.XX.X";
+        } else {
+            bDetected = false;
+        }
     }
 
     //final check for exact version of golang used embedded inside binary


### PR DESCRIPTION
Right now, GoLang detection will never run in case the ".symtab" section is missing. People can extremely easily mess with this, and some obfuscators do this by default.

So, I just refactored the code a bit to include the heuristic approach even in case the section is not found.

Idk if the patterns on their own are strong enough, hence I didn't just remove the check for symtab.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved detection logic for Go binaries, enhancing accuracy in identifying whether a binary is modified or unmodified.
	- Enhanced version identification process based on the presence of specific signatures.

- **Bug Fixes**
	- Resolved issues related to incorrect detection of Go binaries when the `.symtab` section is absent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->