### PR TITLE
MinGW signature fix and improvements

### DIFF
--- a/db/PE/MinGW.4.sg
+++ b/db/PE/MinGW.4.sg
@@ -1,4 +1,5 @@
 // Detect It Easy: detection rule file
+// improved by fernandom - menteb.in - 2025.05
 
 init("compiler", "MinGW");
 
@@ -46,8 +47,10 @@ function detect() {
     else */
 
     if (PE.getMajorLinkerVersion() == 2) {
-        if (!bFPC && (PE.getMinorLinkerVersion() <= 30 || PE.getMinorLinkerVersion() == 36 || PE.getMinorLinkerVersion() == 56)) {
-            if (PE.compare("'MZ'90000300000004000000FFFF0000B800000000000000400000000000000000000000000000000000000000000000000000000000000000000000800000000E1FBA0E00B409CD21B8014CCD21'This program cannot be run in DOS mode.\r\r\n$'0000000000000'PE'0000")) {
+        var minor = PE.getMinorLinkerVersion();
+
+        if(!bFPC && (minor <= 30 || minor == 36 || minor == 41 || minor == 44 || minor == 56)) {
+            if (PE.compare("'MZ'90000300000004000000FFFF0000B800000000000000400000000000000000000000000000000000000000000000000000000000000000000000800000000E1FBA0E00B409CD21B8014CCD21'This program cannot be run in DOS mode.\r\r\n$'00000000000000'PE'0000")) {
                 if (!PE.section[".rsrc"]) {
                     bDetected = true;
                 } else {
@@ -70,6 +73,10 @@ function detect() {
         if (buildidSection && rdataSection) {
             bDetected = PE.isSignaturePresent(rdataSection.FileOffset, rdataSection.FileSize, "'Mingw'");
         }
+    }
+
+    if (bDetected && !PE.isOverlayPresent()) {
+        sOptions = "stripped";
     }
 
     _setLang("C/C++", bDetected);


### PR DESCRIPTION
I believe the `PE.compare()` parameter is missing a '0' character. Also, I've added two `MinorLinkerVersion` values I've seen recently being used with MinGW (41 and 44) and an additional check to inform the user whether the binary is stripped or not.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved detection accuracy for MinGW compiler versions, including support for additional minor linker versions.
  - Enhanced PE signature comparison for more reliable identification.

- **Chores**
  - Added a comment noting recent improvements and authorship.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->