### PR TITLE
Dockerfile updated

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,12 @@
-FROM debian:bookworm-slim
+FROM ubuntu:24.04
 
-RUN apt update -qq && apt upgrade -y && apt install -y wget tar libglib2.0-0 && \
-    wget https://github.com/horsicq/DIE-engine/releases/download/3.01/die_lin64_portable_3.01.tar.gz && \
-    tar -xzf die_lin64_portable_3.01.tar.gz
+RUN apt update -qq && apt upgrade -y  && apt install -y wget && \
+    # Beta version needed to support recent signatures
+    wget https://github.com/horsicq/DIE-engine/releases/download/Beta/die_3.10_Ubuntu_24.04_amd64.deb  && \
+    apt install -y ./die_3.10_Ubuntu_24.04_amd64.deb && \
+    rm die_3.10_Ubuntu_24.04_amd64.deb && rm -rf /usr/lib/die/db
 
 # db update
-RUN rm -rf /die_lin64_portable/base/db
-COPY ./db /die_lin64_portable/base/db
+COPY ./db /usr/lib/die/db
 
-ENTRYPOINT ["/die_lin64_portable/diec.sh"]
+ENTRYPOINT ["/usr/bin/diec"]


### PR DESCRIPTION
Some new signatures have issues with stable release. 
E.g., `TypeError: cannot call readBytes(): unknown return typeQList<qint32>' `

Thus, in order to be able to use the latest DB, you need to use the beta version of DIE.  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the application’s base environment to Ubuntu 24.04 for improved compatibility.
	- Switched to installing DIE-engine via a native Ubuntu package for streamlined setup.
	- Adjusted entrypoint and database locations to align with the new installation method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->