### PR TITLE
Improved Nim compiler detection.

### DIFF
--- a/db/PE/Nim.4.sg
+++ b/db/PE/Nim.4.sg
@@ -9,8 +9,7 @@ function detect() {
         var nOffset = rdataSection.FileOffset,
             nSize = rdataSection.FileSize;
 
-        if (PE.findString(nOffset, nSize, "io.nim") !== -1 || PE.findString(nOffset, nSize, "fatal.nim") !== -1 || PE.findString(nOffset, nSize, "@FATAL") !== -1 || PE.findString(nOffset, nSize, "sysFatal") !== -1 || PE.findString(nOffset, nSize, "NimMain
-") !== -1 || PE.findString(nOffset, nSize, "NimDestroyGlobals") !== -1) {
+        if (PE.findString(nOffset, nSize, "io.nim") !== -1 || PE.findString(nOffset, nSize, "fatal.nim") !== -1 || PE.findString(nOffset, nSize, "@FATAL") !== -1 || PE.findString(nOffset, nSize, "sysFatal") !== -1 || PE.findString(nOffset, nSize, "NimMain") !== -1 || PE.findString(nOffset, nSize, "NimDestroyGlobals") !== -1) {
             bDetected = true;
         }
     }


### PR DESCRIPTION
Added the strings:

- "@fatal"
- "sysFatal"
- "NimMain"
- "NimDestroyGlobals"

Which are likely to be present in binaries compiled with more recent versions of the Nim compiler.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced detection capabilities by expanding recognition of Nim-related signature patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->