### PR TITLE
Make DIE beta package version configurable in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
 FROM ubuntu:24.04
 
+# Newest version of DIE, check https://github.com/horsicq/DIE-engine/releases .
+ARG DIE_VERSION=3.20
 RUN apt update -qq && apt upgrade -y  && apt install -y wget && \
-    # Beta version needed to support recent signatures
-    wget https://github.com/horsicq/DIE-engine/releases/download/Beta/die_3.11_Ubuntu_24.04_amd64.deb  && \
-    apt install -y ./die_3.11_Ubuntu_24.04_amd64.deb && \
-    rm die_3.11_Ubuntu_24.04_amd64.deb && rm -rf /usr/lib/die/db
+    wget https://github.com/horsicq/DIE-engine/releases/download/Beta/die_${DIE_VERSION}_Ubuntu_24.04_amd64.deb && \
+    apt install -y ./die_${DIE_VERSION}_Ubuntu_24.04_amd64.deb && \
+    rm die_${DIE_VERSION}_Ubuntu_24.04_amd64.deb && rm -rf /usr/lib/die/db
 
 # db update
 COPY ./db /usr/lib/die/db


### PR DESCRIPTION
This PR fixes the Docker build failure caused by a hard-coded Beta package filename in Dockerfile.

Problem
The current Dockerfile downloads a version-specific Beta package file:
die_3.11_Ubuntu_24.04_amd64.deb

When the Beta asset version changes, the old file path can return HTTP 404 and break container builds.

Change
- Add ARG DIE_VERSION=3.20
- Replace the hard-coded package filename with die_${DIE_VERSION}_Ubuntu_24.04_amd64.deb

Why
This keeps the existing Beta-based workflow while making the package version configurable for future updates.

Tested
- podman build completed successfully
- diec ran successfully after build

Note
I noticed CONTRIBUTING.md mentions opening pull requests against the main branch, while the repository currently shows master. I opened this PR against the branch currently used by the repository.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Container image now accepts a configurable version parameter for the included tool, defaulting to 3.20.
  * Added an explicit container entrypoint for consistent startup.

* **Chores**
  * Installation now uses the specified version throughout and continues to remove the installer and cleanup application artifacts after install.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->