### PR TITLE
Fix: Prevent false UPX heuristic detections on manually unpacked files

### DIFF
--- a/db/PE/__GenericHeuristicAnalysis_By_DosX.7.sg
+++ b/db/PE/__GenericHeuristicAnalysis_By_DosX.7.sg
@@ -2394,6 +2394,7 @@ function scanForPackersAndCryptors_NET_and_Native() { // For .NET and Native app
     var isUpxLikeImports = false;
 
     if (PE_Cached.numberOfSections === 3 &&
+        PE.section[0].FileSize === 0 &&
         (PE.section[0].Characteristics & SECTION_FLAGS_RWX_MASK) === SECTION_FLAGS_RWX_MASK &&
         (PE.section[1].Characteristics & SECTION_FLAGS_RWX_MASK) === SECTION_FLAGS_RWX_MASK && (
             (PE.section[2].Characteristics & SECTION_FLAGS_READ) === SECTION_FLAGS_READ ||

--- a/db/PE/__GenericHeuristicAnalysis_By_DosX.7.sg
+++ b/db/PE/__GenericHeuristicAnalysis_By_DosX.7.sg
@@ -2845,12 +2845,16 @@ function scanForPackersAndCryptors_NET_and_Native() { // For .NET and Native app
 
     var versionBySectionDetected = String();
 
-    if (sectionNamesValidatingResult != null) {
-        versionBySectionDetected = sectionNamesValidatingResult[1];
-
-        log(logType.nothing, "Sections like " + sectionNamesValidatingResult[0] + (versionBySectionDetected ? " (v" + versionBySectionDetected + ")" : String()));
-
-        isSectionNameLikePacker = true;
+     if (sectionNamesValidatingResult != null) {
+        if (!(
+            (sectionNamesValidatingResult[0] === "UPX" ) &&
+            (PE.section[0].FileSize !== 0))
+            ) 
+            {
+            versionBySectionDetected = sectionNamesValidatingResult[1];
+            log(logType.nothing, "Sections like " + sectionNamesValidatingResult[0] + (versionBySectionDetected ? " (v" + versionBySectionDetected + ")" : String()));
+            isSectionNameLikePacker = true;
+        }
     }
 
     // Clean up: release the dictionary
@@ -2915,8 +2919,10 @@ function scanForPackersAndCryptors_NET_and_Native() { // For .NET and Native app
         isCollisionInSectionsPresent = true;
     }
 
-    if (isCollisionInSectionsPresent) options = addOption(options, "Sections collision (\"" + clearSectionName(sectionNameCollision) + "\")");
-
+    if (isCollisionInSectionsPresent &&
+        !(sectionNameCollision === "UPX" && PE.section[0].FileSize !== 0)) {
+        options = addOption(options, "Sections collision (\"" + clearSectionName(sectionNameCollision) + "\")");
+    }
 
 
 
@@ -4652,8 +4658,10 @@ function scanForObfuscations_Native() {
         }
     }
 
-    if (isRwxSectionPresent) options = addOption(options, "Section #" + rwxSectionIndex + " (\"" + clearSectionName(PE.getSectionName(rwxSectionIndex)) + "\") has RWX");
-
+    if (isRwxSectionPresent && 
+        !(rwxSectionIndex === 0 && /^UPX[0-3]$/.test(PE.getSectionName(rwxSectionIndex)) && PE.section[0].FileSize !== 0)) {
+        options = addOption(options, "Section #" + rwxSectionIndex + " (\"" + clearSectionName(PE.getSectionName(rwxSectionIndex)) + "\") has RWX");
+    }
 
 
 


### PR DESCRIPTION
Added a conditional check for the first section's Raw Size (FileSize === 0). Manually unpacked/dumped UPX files have a UPX0 Raw Size greater than zero since the uncompressed code is written to it. This prevents the heuristic engine from flagging dumped files as packed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection accuracy by tightening UPX-like structural checks to reduce false positives.
  * Suppressed collision reporting when collisions are identified as UPX and the primary section size indicates a non-UPX layout.
  * Prevented improper RWX marking for UPX-style primary sections when their size suggests they are not genuine executable segments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->