### PR TITLE
FIX/Enhance Fatpack detection of PE files

### DIFF
--- a/db/PE/packer_Fatpack.2.sg
+++ b/db/PE/packer_Fatpack.2.sg
@@ -7,29 +7,37 @@
 
 // https://github.com/Fatmike-GH/Fatpack
 meta("packer", "Fatpack");
-
 function detect() {
-    if (!PE.isNet() && PE.is64() && PE.isTLSPresent()) {
-        if (PE.getNumberOfImports() === 1 && PE.isImportPositionHashPresent(0, 0x74244911)) {
-            bDetected = true;
-
-            if (PE.getNumberOfSections() === 6 && PE.getNumberOfResources() > 0) {
-                sOptions = "resources payload";
-
-                if (!PE.isResourceNamePresent("FPACK")) {
-                    sOptions = sOptions.append("modified");
-                }
-            } else if (PE.getNumberOfSections() === 5) {
-                sOptions = "section payload";
-
-                if (PE.section[PE.nLastSection].Name !== ".fpack  ") {
-                    sOptions = sOptions.append("modified");
-                }
-            } else {
-                sVersion = "custom";
-            }
-        }
+if (!PE.isNet() && PE.is64() && PE.isTLSPresent()) {
+if (PE.getNumberOfImports() === 1 && PE.getNumberOfSections() === 6 && PE.isImportPositionHashPresent(0, 0x74244911)) {
+			var Number_of_Sections=6
+			bDetected = false;
+			for (var i=0;i<Number_of_Sections;++i){
+			if (PE.section[i].FileSize === 0){
+						 bDetected = true;
+						 break;
+ }
+}
+			 
+			
+if ( PE.getNumberOfResources() > 1) {   
+            sOptions = "resources payload";
+            if (!PE.isResourceNamePresent("FPACK")) {
+                sOptions = sOptions.append("modified");
     }
-
-    return result();
+}
+else{
+    sOptions = "section payload";
+    if(PE.section[PE.nLastSection].Name !== ".fpack  ") {          
+        sOptions = sOptions.append("modified");
+    }
+    else{
+        sVersion = "custom";
+    }
+    
+  }
+  
+ }
+}
+return result();
 }


### PR DESCRIPTION
### Problem

The current detection logic has an issue: it relies on the number of sections to distinguish between the payload storage methods. The rule assumes that if the executable has 5 sections, it uses the section-based payload option. However, in practice, both the resource-based and section-based payload variants contain 6 sections. As a result, this can lead to false positives where a section-based payload is incorrectly identified as a resource-based payload.

Additionally, manually unpacked samples produced from this packer may cause another issue. After unpacking, the data section’s raw size becomes greater than zero, whereas in the original packed sample it is zero. Therefore, an additional check should be added to verify the raw size of the data section in order to reduce false positives when analyzing unpacked samples.

Here is a photo of packed sample with “Section” option being incorrectly detected as a resource-based payload by the current detection rule→

<img width="1027" height="806" alt="image" src="https://github.com/user-attachments/assets/70c8a697-6105-4892-980d-cb127ede2261" />



But it is actually packed with “Section” option in Fatpack ->


<img width="1182" height="825" alt="image1" src="https://github.com/user-attachments/assets/675aa8c0-e8d8-42a1-9d2b-686370a27ff9" />

I have tested the new changes on 4 samples:

1-packed_with_fatpack_ROption.exe

2-packed_with_fatpack_SOption.exe

3-packed_with_fatpack_ROption_Manually_unpacked.exe

4-packed_with_fatpack_SOption_manaually_unpacked.bin

here is the link to the samples : https://drive.google.com/drive/folders/1QEd2xSusWWulzGZOV8H0LL30Z4eefBM7?usp=sharing

here is a photo of both two different packed files , one with “resource” option and other with “section” option, we can see that the “.data” section has > 0 size when manually unpacked.

<img width="1181" height="838" alt="image3" src="https://github.com/user-attachments/assets/5d88212b-e218-4a82-9111-52064e9a2841" />



<img width="1187" height="837" alt="image4" src="https://github.com/user-attachments/assets/2444d6ba-198e-42de-ab58-44b698e462b1" />


**After modification →**

packed with -R option

<img width="927" height="742" alt="image5" src="https://github.com/user-attachments/assets/fd25be5d-96ff-4ca7-9263-720c9d26d9da" />


packed with -S option



<img width="929" height="736" alt="image6" src="https://github.com/user-attachments/assets/5c387210-5ff2-47e1-854f-f19805c98ff3" />



### Modifications Made

Added a check for number of section===6, and a for loop to check if one section is zero-sized.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection accuracy with stricter classification criteria
  * Refined payload identification logic based on resource and structural analysis
  * Simplified version derivation methodology

<!-- end of auto-generated comment: release notes by coderabbit.ai -->