### PR TITLE
Fix/fat pack detection enhancement

### DIFF
--- a/db/PE/packer_Fatpack.2.sg
+++ b/db/PE/packer_Fatpack.2.sg
@@ -7,29 +7,37 @@
 
 // https://github.com/Fatmike-GH/Fatpack
 meta("packer", "Fatpack");
-
 function detect() {
-    if (!PE.isNet() && PE.is64() && PE.isTLSPresent()) {
-        if (PE.getNumberOfImports() === 1 && PE.isImportPositionHashPresent(0, 0x74244911)) {
-            bDetected = true;
-
-            if (PE.getNumberOfSections() === 6 && PE.getNumberOfResources() > 0) {
-                sOptions = "resources payload";
-
-                if (!PE.isResourceNamePresent("FPACK")) {
-                    sOptions = sOptions.append("modified");
-                }
-            } else if (PE.getNumberOfSections() === 5) {
-                sOptions = "section payload";
-
-                if (PE.section[PE.nLastSection].Name !== ".fpack  ") {
-                    sOptions = sOptions.append("modified");
-                }
-            } else {
-                sVersion = "custom";
-            }
-        }
+if (!PE.isNet() && PE.is64() && PE.isTLSPresent()) {
+if (PE.getNumberOfImports() === 1 && PE.getNumberOfSections() === 6 && PE.isImportPositionHashPresent(0, 0x74244911)) {
+			var Number_of_Sections=6
+			bDetected = false;
+			for (var i=0;i<Number_of_Sections;++i){
+			if (PE.section[i].FileSize === 0){
+						 bDetected = true;
+						 break;
+ }
+}
+			 
+			
+if ( PE.getNumberOfResources() > 1) {   
+            sOptions = "resources payload";
+            if (!PE.isResourceNamePresent("FPACK")) {
+                sOptions = sOptions.append("modified");
     }
-
-    return result();
+}
+else{
+    sOptions = "section payload";
+    if(PE.section[PE.nLastSection].Name !== ".fpack  ") {          
+        sOptions = sOptions.append("modified");
+    }
+    else{
+        sVersion = "custom";
+    }
+    
+  }
+  
+ }
+}
+return result();
 }


### PR DESCRIPTION
This PR continues the work from #350
I have corrected the detection logic as follows:

1-Since different versions of "fatpack" do not have a constant number of sections, I eliminated that criterion from the code.
2-Avoided false detections for manually unpacked samples.
3-Improved the detection of packed samples using the --resources option by looping through all resources and searching for the signature "5D00001000" in any of them. If found, it means the resource payload has been identified. This modification is more reliable because resource names and counts can be modified or manipulated, so the detection now relies on deeper analysis.
4-Improved the code readability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Database Updates**
  * Refined detection logic for PE packer variants with improved accuracy and performance in identifying Fatpack.2 samples.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/horsicq/Detect-It-Easy/pull/352)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->