### PR TITLE
Enhanced Fatpack detection

### DIFF
--- a/db/PE/packer_Fatpack.2.sg
+++ b/db/PE/packer_Fatpack.2.sg
@@ -7,29 +7,38 @@
 
 // https://github.com/Fatmike-GH/Fatpack
 meta("packer", "Fatpack");
-
 function detect() {
     if (!PE.isNet() && PE.is64() && PE.isTLSPresent()) {
         if (PE.getNumberOfImports() === 1 && PE.isImportPositionHashPresent(0, 0x74244911)) {
-            bDetected = true;
-
-            if (PE.getNumberOfSections() === 6 && PE.getNumberOfResources() > 0) {
-                sOptions = "resources payload";
-
-                if (!PE.isResourceNamePresent("FPACK")) {
-                    sOptions = sOptions.append("modified");
+            for (var i = 0; i < PE.getNumberOfSections(); ++i) {
+                if (PE.section[i].FileSize === 0) {
+                    bDetected = true;
+                    break;
                 }
-            } else if (PE.getNumberOfSections() === 5) {
-                sOptions = "section payload";
+            }
 
+            if (PE.getNumberOfResources() > 0) {
+                for (var i = 0; i < PE.getNumberOfResources(); ++i) {
+                    if (PE.compare("5D00001000", PE.getResourceOffsetByNumber(i))) {
+                        sOptions = "resources payload";
+                        if (PE.getResourceNameByNumber(i) !== "FPACK") {
+                            sOptions = sOptions.append("modified");
+                        }
+                        break;
+                    }
+                }
+            }
+
+            if (!sOptions) {
+                sOptions = "section payload";
                 if (PE.section[PE.nLastSection].Name !== ".fpack  ") {
                     sOptions = sOptions.append("modified");
+                } 
+                else {
+                    sVersion = "custom";
                 }
-            } else {
-                sVersion = "custom";
             }
         }
     }
-
     return result();
 }


### PR DESCRIPTION
Enhanced FatPack detection
I have corrected the detection logic as follows:

1-Since different versions of "fatpack" do not have a constant number of sections, I eliminated that criterion from the code. 
2-Avoided false detections for manually unpacked samples. 
3-Improved the detection of packed samples using the --resources option by looping through all resources and searching for the signature "5D00001000" in any of them. If found, it means the resource payload has been identified. This modification is more reliable because resource names and counts can be modified or manipulated, so the detection now relies on deeper analysis. 
4-Improved the code readability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refined detection logic for improved accuracy in identifying packed executable resources.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/horsicq/Detect-It-Easy/pull/354)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->