### PR TITLE
Add inject2pe detection rule

### DIFF
--- a/db/PE/tool.inject2pe.2.sg
+++ b/db/PE/tool.inject2pe.2.sg
@@ -1,0 +1,13 @@
+// Detect It Easy: detection rule file
+// Author: Yosef Khaled
+// This is a detection rule for inject2pe tool that either inject a shellcode to pe file or wrap a shellcode in a pe file, this rule file will detect the wrapper method
+// link of the tool: https://github.com/0xballistics/inject2pe
+
+meta("tool", "inject2pe");
+function detect() {
+    if(PE.getNumberOfImports() == 0 && PE.getNumberOfSections() == 1 && PE.calculateSizeOfHeaders() == 0x200 && PE.section[0].Characteristics == 0xE0000020 && !PE.isConsole()) {
+        bDetected=true;
+        sOptions = "shellcode2exe wrapper";
+    }
+    return result();
+}

--- a/db/PE/tool.inject2pe.2.sg
+++ b/db/PE/tool.inject2pe.2.sg
@@ -6,8 +6,8 @@
 meta("tool", "inject2pe");
 function detect() {
     if(PE.getNumberOfImports() == 0 && PE.getNumberOfSections() == 1 && PE.calculateSizeOfHeaders() == 0x200 && PE.section[0].Characteristics == 0xE0000020 && !PE.isConsole()) {
-        bDetected=true;
         sOptions = "shellcode2exe wrapper";
+        bDetected = true; 
     }
     return result();
 }

--- a/db/PE/tool.inject2pe.2.sg
+++ b/db/PE/tool.inject2pe.2.sg
@@ -1,13 +1,13 @@
 // Detect It Easy: detection rule file
 // Author: Yosef Khaled
 // This is a detection rule for inject2pe tool that either inject a shellcode to pe file or wrap a shellcode in a pe file, this rule file will detect the wrapper method
-// link of the tool: https://github.com/0xballistics/inject2pe
-
+// https://github.com/0xballistics/inject2pe
 meta("tool", "inject2pe");
+
 function detect() {
-    if(PE.getNumberOfImports() == 0 && PE.getNumberOfSections() == 1 && PE.calculateSizeOfHeaders() == 0x200 && PE.section[0].Characteristics == 0xE0000020 && !PE.isConsole()) {
+    if (PE.getNumberOfImports() == 0 && PE.getNumberOfSections() == 1 && PE.calculateSizeOfHeaders() == 0x200 && PE.section[0].Characteristics == 0xE0000020 && !PE.isConsole()) {
         sOptions = "shellcode2exe wrapper";
         bDetected = true; 
     }
-    return result();
+        return result();
 }


### PR DESCRIPTION
Add a Detect It Easy (DIE) rule to identify the inject2pe tool's **wrapper method**. 
The rule tags files with meta tool="inject2pe" and matches **PEs with no imports**, **a single section**, **SizeOfHeaders == 0x200**, **first section Characteristics == 0xE0000020**, and **not a console binary**; it sets options to "shellcode2exe wrapper".
While the only section name is ".inj", I decided not to use that criterion since the name can be changed easily.
I have tested the tool on many samples with different lengths of shellcode converted to PE.
<img width="983" height="717" alt="shellcodetope" src="https://github.com/user-attachments/assets/62a81330-55d8-4dc3-8285-cb5479f7ceda" />
link to the tool: https://github.com/0xballistics/inject2pe


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a detection rule to identify binaries produced by the "inject2pe" shellcode-to-PE wrapper, improving automated classification, labeling, and handling of such samples during scans and analysis.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/horsicq/Detect-It-Easy/pull/355)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->