### PR TITLE
Add PyArmor detect

### DIFF
--- a/db/Binary/PyArmor.sg
+++ b/db/Binary/PyArmor.sg
@@ -8,9 +8,10 @@ init("protector", "PyArmor");
 
 function detect(bShowType, bShowVersion, bShowOptions)
 {
-    var bDetected = false;
+    bDetected = false;
+    sOptions = "";
+
     var bRuntime = false;
-    var sOptions = "";
 
     // __pyarmor__
     var nSig1 = Binary.findSignature(

--- a/db/Binary/PyArmor.sg
+++ b/db/Binary/PyArmor.sg
@@ -1,0 +1,64 @@
+// DIE's signature file
+// PyArmor detector
+// based on runtime/module/string signatures
+
+// author t.me/msc_Tech
+
+init("protector", "PyArmor");
+
+function detect(bShowType, bShowVersion, bShowOptions)
+{
+    var bDetected = false;
+    var bRuntime = false;
+    var sOptions = "";
+
+    // __pyarmor__
+    var nSig1 = Binary.findSignature(
+        0,
+        Binary.getSize(),
+        "5F5F707961726D6F725F5F"
+    );
+
+    // pyarmor_runtime_
+    var nSig2 = Binary.findSignature(
+        0,
+        Binary.getSize(),
+        "707961726D6F725F72756E74696D655F"
+    );
+
+    // PyInit_pyarmor_runtime
+    var nSig3 = Binary.findSignature(
+        0,
+        Binary.getSize(),
+        "5079496E69745F707961726D6F725F72756E74696D65"
+    );
+
+    // .pyarmor\pack\dist\
+    var nSig4 = Binary.findSignature(
+        0,
+        Binary.getSize(),
+        "2E707961726D6F725C7061636B5C646973745C"
+    );
+
+    if (
+        nSig1 != -1 ||
+        nSig2 != -1 ||
+        nSig3 != -1 ||
+        nSig4 != -1
+    )
+    {
+        bDetected = true;
+
+        if (nSig3 != -1)
+        {
+            bRuntime = true;
+        }
+
+        if (bRuntime)
+        {
+            sOptions = "Runtime module";
+        }
+    }
+
+    return result(bShowType, bShowVersion, bShowOptions);
+}


### PR DESCRIPTION
adds PyArmor runtime/module detection based on:
- __pyarmor__
- pyarmor_runtime_
- PyInit_pyarmor_runtime
- .pyarmor\pack\dist\

Tested on protected Python binaries.

<img width="1040" height="681" alt="image" src="https://github.com/user-attachments/assets/e3353f36-c1fe-4f81-a2a3-0e310910a681" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added PyArmor protector detection for binaries, including optional reporting of protector type and version and explicit marking when a runtime-module signature is detected. This improves accuracy of protector identification and provides clearer detection output when requested, helping users better understand protection characteristics of inspected binaries.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/horsicq/Detect-It-Easy/pull/357)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->