### PR TITLE
Added the detection of "pkr_ce1a" packer

### DIFF
--- a/db/PE/packer_pkr_ce1a.2.sg
+++ b/db/PE/packer_pkr_ce1a.2.sg
@@ -1,6 +1,8 @@
 // Detect It Easy: detection rule file
 // Author: Yosef Khaled
 
+// https://malwarology.substack.com/p/malicious-packer-pkr_ce1a
+// https://cyvia.io/blog/a-closer-look-at-the-pkr-ce1a-packer
 meta("packer", "pkr_ce1a");
 
 function detect() {

--- a/db/PE/packer_pkr_ce1a.2.sg
+++ b/db/PE/packer_pkr_ce1a.2.sg
@@ -1,0 +1,12 @@
+// Detect It Easy: detection rule file
+// Author: Yosef Khaled
+
+meta("packer", "pkr_ce1a");
+
+function detect() {
+    if (PE.isSignaturePresent(0, PE.getSize(), "00699AF974........96AACB4600")) {
+        bDetected = true;
+    }
+
+    return result();
+}


### PR DESCRIPTION
I added a detection rule file under "/db/PE" to detect a packer called "pkr_ce1a" used by malware authors.
This packer is polymorphic, with variants and builds sharing many of the same functionality, behavior, and code features while differing in their ordering and using randomized opaque predicates, junk code, and dead code. Despite these variations, detection is still possible by focusing on two stable byte sequences identified in the referenced research articles.
I have tested the rule on 5 samples packed with that packer
References:
- https://malwarology.substack.com/p/malicious-packer-pkr_ce1a
- https://cyvia.io/blog/a-closer-look-at-the-pkr-ce1a-packer

Test_Samples (Be cautious, samples are all malware):
https://drive.google.com/drive/folders/1sDRo3dLvFKlapR_cg6OizRy3ttxo7UOq?usp=sharing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a detection rule to expand malware detection for an additional packer variant, improving identification of packed PE files and strengthening threat analysis and classification.
  * Enhances overall coverage for suspicious code detection, helping users receive more accurate alerts and analysis results.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/horsicq/Detect-It-Easy/pull/359)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->