### PR TITLE
Create sfx_Makeself.1.sg

### DIFF
--- a/db/Binary/sfx_Makeself.1.sg
+++ b/db/Binary/sfx_Makeself.1.sg
@@ -7,21 +7,21 @@ function detect() {
     var nSize = Math.min(16384, Binary.getSize());
     if (nSize < 64) return result();
 
-    if (!Binary.isSignaturePresent(0, 2, "2321")) { // #!
+    if (!Binary.isSignaturePresent(0, 2, "2321")) {
         return result();
     }
 
-    var sFileContent = Binary.getString(0, nSize).toLowerCase();
+    var sFileContent = Binary.getString(0, nSize);
     
-    var sVersionMatch = sFileContent.match(/ms_version\s*=\s*"([^"]+)"/) || 
-                       sFileContent.match(/ms_version\s*=\s*([0-9.]+)/) ||
-                       sFileContent.match(/makeself version\s+([0-9.]+)/);
+    var sVersionMatch = sFileContent.match(/MS_VERSION\s*=\s*"([^"]+)"/i) || 
+                       sFileContent.match(/MS_VERSION\s*=\s*([0-9.]+)/i) || 
+                       sFileContent.match(/Makeself version\s+([0-9.]+)/i);
     
     if (sVersionMatch) {
         bDetected = true;
         sVersion = sVersionMatch[1];
     } 
-    else if (sFileContent.indexOf("ms_version=") !== -1) {
+    else if (sFileContent.toLowerCase().indexOf("ms_version=") !== -1) {
         bDetected = true;
     }
 

--- a/db/Binary/sfx_Makeself.1.sg
+++ b/db/Binary/sfx_Makeself.1.sg
@@ -1,7 +1,7 @@
 // Detect It Easy: detection rule file
 // Authors: 6eh01der <ras_atari@mail.ru>, (TG@Ibeh01derI)
 
-init("sfx", "Makeself SFX archive");
+meta("sfx", "Makeself SFX archive");
 
 function detect() {
     var nSize = Math.min(16384, Binary.getSize());

--- a/db/Binary/sfx_Makeself.1.sg
+++ b/db/Binary/sfx_Makeself.1.sg
@@ -7,23 +7,19 @@ function detect() {
     var nSize = Math.min(16384, Binary.getSize());
     if (nSize < 64) return result();
 
-    if (!Binary.isSignaturePresent(0, 2, "2321")) {
+    if (!Binary.isSignaturePresent(0, 2, "2321")) { // #!
         return result();
     }
 
-    var sFileContent = Binary.getString(0, nSize);
+    var sFileContent = Binary.getString(0, nSize).toLowerCase();
     
-    var sVersionMatch = sFileContent.match(/MS_VERSION\s*=\s*"([^"]+)"/i) || 
-                       sFileContent.match(/Makeself version\s+([0-9.]+)/i);
+    var sVersionMatch = sFileContent.match(/ms_version\s*=\s*"([^"]+)"/) || 
+                       sFileContent.match(/ms_version\s*=\s*([0-9.]+)/) ||
+                       sFileContent.match(/makeself version\s+([0-9.]+)/);
     
     if (sVersionMatch) {
         bDetected = true;
-        
-        if (sVersionMatch[1]) {
-            sVersion = sVersionMatch[1];
-        } else if (sVersionMatch[0]) {
-            sVersion = sVersionMatch[0].replace(/[^0-9.]/g, '');
-        }
+        sVersion = sVersionMatch[1];
     } 
     else if (sFileContent.indexOf("ms_version=") !== -1) {
         bDetected = true;

--- a/db/Binary/sfx_Makeself.1.sg
+++ b/db/Binary/sfx_Makeself.1.sg
@@ -1,0 +1,36 @@
+// Detect It Easy: detection rule file
+// Authors: 6eh01der <ras_atari@mail.ru>, (TG@Ibeh01derI)
+
+init("sfx", "Makeself SFX archive");
+
+function detect() {
+    var nSize = Math.min(16384, Binary.getSize());
+    if (nSize < 64) return result();
+
+    if (!Binary.isSignaturePresent(0, 2, "2321")) {
+        return result();
+    }
+
+    var sFileContent = Binary.getString(0, nSize);
+    var sLowerContent = sFileContent.toLowerCase();
+
+    if (sLowerContent.indexOf("makeself version") !== -1 || 
+        sLowerContent.indexOf("ms_version=") !== -1 || 
+        sLowerContent.indexOf("makeself") !== -1) {
+        
+        bDetected = true;
+        
+        var sVersionMatch = sFileContent.match(/MS_VERSION\s*=\s*"([^"]+)"/i) || 
+                           sFileContent.match(/Makeself version\s+([0-9.]+)/i);
+        
+        if (sVersionMatch) {
+            if (sVersionMatch.length > 1 && sVersionMatch[1]) {
+                sVersion = sVersionMatch[1];
+            } else if (sVersionMatch[0]) {
+                sVersion = sVersionMatch[0].replace(/[^0-9.]/g, '');
+            }
+        }
+    }
+
+    return result();
+}

--- a/db/Binary/sfx_Makeself.1.sg
+++ b/db/Binary/sfx_Makeself.1.sg
@@ -1,5 +1,5 @@
 // Detect It Easy: detection rule file
-// Authors: 6eh01der <ras_atari@mail.ru>, (TG@Ibeh01derI)
+// Authors: 6eh01der <ras_atari@mail.ru>, (TG@Ibeh01derI), Improved by AI
 
 meta("sfx", "Makeself SFX archive");
 
@@ -12,24 +12,21 @@ function detect() {
     }
 
     var sFileContent = Binary.getString(0, nSize);
-    var sLowerContent = sFileContent.toLowerCase();
-
-    if (sLowerContent.indexOf("makeself version") !== -1 || 
-        sLowerContent.indexOf("ms_version=") !== -1 || 
-        sLowerContent.indexOf("makeself") !== -1) {
-        
+    
+    var sVersionMatch = sFileContent.match(/MS_VERSION\s*=\s*"([^"]+)"/i) || 
+                       sFileContent.match(/Makeself version\s+([0-9.]+)/i);
+    
+    if (sVersionMatch) {
         bDetected = true;
         
-        var sVersionMatch = sFileContent.match(/MS_VERSION\s*=\s*"([^"]+)"/i) || 
-                           sFileContent.match(/Makeself version\s+([0-9.]+)/i);
-        
-        if (sVersionMatch) {
-            if (sVersionMatch.length > 1 && sVersionMatch[1]) {
-                sVersion = sVersionMatch[1];
-            } else if (sVersionMatch[0]) {
-                sVersion = sVersionMatch[0].replace(/[^0-9.]/g, '');
-            }
+        if (sVersionMatch[1]) {
+            sVersion = sVersionMatch[1];
+        } else if (sVersionMatch[0]) {
+            sVersion = sVersionMatch[0].replace(/[^0-9.]/g, '');
         }
+    } 
+    else if (sFileContent.indexOf("ms_version=") !== -1) {
+        bDetected = true;
     }
 
     return result();

--- a/db/Binary/sfx_Makeself.1.sg
+++ b/db/Binary/sfx_Makeself.1.sg
@@ -4,25 +4,50 @@
 meta("sfx", "Makeself SFX archive");
 
 function detect() {
+    var nTotalSize = Binary.getSize();
     var nSize = Math.min(16384, Binary.getSize());
     if (nSize < 64) return result();
 
-    if (!Binary.isSignaturePresent(0, 2, "2321")) {
+    if (!Binary.isSignaturePresent(0, 2, "2321")) { // #!
         return result();
     }
 
-    var sFileContent = Binary.getString(0, nSize);
+    var sFileContent = Binary.getString(0, nSize).toLowerCase();
     
-    var sVersionMatch = sFileContent.match(/MS_VERSION\s*=\s*"([^"]+)"/i) || 
-                       sFileContent.match(/MS_VERSION\s*=\s*([0-9.]+)/i) || 
-                       sFileContent.match(/Makeself version\s+([0-9.]+)/i);
+    var sVersionMatch = sFileContent.match(/ms_version\s*=\s*"([^"]+)"/) || 
+                       sFileContent.match(/ms_version\s*=\s*([0-9.]+)/) ||
+                       sFileContent.match(/makeself version\s+([0-9.]+)/);
     
     if (sVersionMatch) {
         bDetected = true;
         sVersion = sVersionMatch[1];
     } 
-    else if (sFileContent.toLowerCase().indexOf("ms_version=") !== -1) {
+    else if (sFileContent.indexOf("ms_version=") !== -1) {
         bDetected = true;
+    }
+
+    if (bDetected) {
+        var bHasBinary = false;
+        
+        var nCheckSize = Math.min(512, nTotalSize);
+        var nCheckOffset = nTotalSize - nCheckSize;
+
+        if (Binary.findByte(nCheckOffset, nCheckSize, 0x00) !== -1) {
+            bHasBinary = true;
+        } else {
+            for (var i = 0; i < nCheckSize; i++) {
+                var byteVal = Binary.readByte(nCheckOffset + i);
+                if (byteVal < 32 && byteVal !== 9 && byteVal !== 10 && byteVal !== 13) {
+                    bHasBinary = true;
+                    break;
+                }
+            }
+        }
+
+        if (!bHasBinary) {
+            bDetected = false;
+            sVersion = "";
+        }
     }
 
     return result();


### PR DESCRIPTION
Makeself detector

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added detection for Makeself SFX archives so the app can identify this self-extracting archive format.
  * Detection examines initial file content for Makeself markers and attempts to extract and normalize Makeself version information when present.
  * Improved handling of very small or non-conforming files to reduce false negatives and improve detection accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->