### PR TITLE
Fedora Qt6 Build

### DIFF
--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -155,6 +155,12 @@ sudo make install
 sudo apt-get install --quiet --assume-yes build-essential qt6-base-dev qt6-base-dev-tools qt6-tools-dev-tools qt6-5compat-dev libqt6svg6-dev qt6-declarative-dev
 ```
 
+#### (Fedora) Install Qt Framework:
+
+```bash
+sudo dnf install qt6-qtbase-devel qt6-qtscript-devel qt6-qttools-devel qt6-qt5compat-devel qt6-qtdeclarative-devel git make gcc-c++
+```
+
 #### Clone this repo recursively:
 
 ```bash


### PR DESCRIPTION
Hi, I added Fedora instructions to the Qt6 part of the build instructions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Added build setup instructions for installing Qt Framework on Fedora systems using the dnf package manager.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->