### PR TITLE
add tprt detection rule files

### DIFF
--- a/db/APK/protector_TPRT.2.sg
+++ b/db/APK/protector_TPRT.2.sg
@@ -2,6 +2,7 @@
 
 // Author: Moli13337
 // GitHub: https://github.com/Moli13337
+// Reference: https://www.52pojie.cn/thread-1487669-1-1.html
 
 meta("protector", "TPRT");
 

--- a/db/APK/protector_TPRT.2.sg
+++ b/db/APK/protector_TPRT.2.sg
@@ -39,6 +39,18 @@ function detect() {
     } else if (APK.isArchiveRecordPresent("lib/x86/libtersafe.so")) {
         sOptions = "x86";
         bDetected = true;
+    } else if (APK.isArchiveRecordPresent("lib/arm64-v8a/libtersafe2.so")) {
+        sOptions = "arm64-v8a";
+        bDetected = true;
+    } else if (APK.isArchiveRecordPresent("lib/armeabi-v7a/libtersafe2.so")) {
+        sOptions = "armeabi-v7a";
+        bDetected = true;
+    } else if (APK.isArchiveRecordPresent("lib/armeabi/libtersafe2.so")) {
+        sOptions = "armeabi";
+        bDetected = true;
+    } else if (APK.isArchiveRecordPresent("lib/x86/libtersafe2.so")) {
+        sOptions = "x86";
+        bDetected = true;
     }
 
     return result();

--- a/db/APK/protector_TPRT.2.sg
+++ b/db/APK/protector_TPRT.2.sg
@@ -2,7 +2,7 @@
 
 // Author: Moli13337
 // GitHub: https://github.com/Moli13337
-// Reference: https://www.52pojie.cn/thread-1487669-1-1.html
+// Reference: https://bbs.kanxue.com/thread-266762.htm
 
 meta("protector", "TPRT");
 

--- a/db/APK/protector_TPRT.2.sg
+++ b/db/APK/protector_TPRT.2.sg
@@ -1,0 +1,28 @@
+// Detect It Easy: detection rule file
+
+// Author: Moli13337
+// GitHub: https://github.com/Moli13337
+
+meta("protector", "TPRT");
+
+function detect() {
+    bDetected =
+        APK.isArchiveRecordPresent("assets/__tpinfo.tp") ||
+        APK.isArchiveRecordPresent("assets/__tpinfo.tsc") ||
+        APK.isArchiveRecordPresent("assets/__tpinfo.tsc.sig") ||
+        APK.isArchiveRecordPresent("assets/__tpinfo.tsd") ||
+        APK.isArchiveRecordPresent("assets/__tpinfo.tsd.sig") ||
+        APK.isArchiveRecordPresent("assets/__tpcfinfo.tsa") ||
+        APK.isArchiveRecordPresent("assets/__tpsinfo.t.p.sin") ||
+        APK.isArchiveRecordPresent("assets/tpginf.dat") ||
+        APK.isArchiveRecordPresent("lib/arm64-v8a/libtprt.so") ||
+        APK.isArchiveRecordPresent("lib/armeabi-v7a/libtprt.so") ||
+        APK.isArchiveRecordPresent("lib/armeabi/libtprt.so") ||
+        APK.isArchiveRecordPresent("lib/x86/libtprt.so") ||
+        APK.isArchiveRecordPresent("lib/arm64-v8a/libtersafe2.so") ||
+        APK.isArchiveRecordPresent("lib/armeabi-v7a/libtersafe2.so") ||
+        APK.isArchiveRecordPresent("lib/armeabi/libtersafe2.so") ||
+        APK.isArchiveRecordPresent("lib/x86/libtersafe2.so");
+
+    return result();
+}

--- a/db/APK/protector_TPRT.2.sg
+++ b/db/APK/protector_TPRT.2.sg
@@ -6,23 +6,40 @@
 meta("protector", "TPRT");
 
 function detect() {
-    bDetected =
-        APK.isArchiveRecordPresent("assets/__tpinfo.tp") ||
+    if (APK.isArchiveRecordPresent("assets/__tpinfo.tp") ||
         APK.isArchiveRecordPresent("assets/__tpinfo.tsc") ||
         APK.isArchiveRecordPresent("assets/__tpinfo.tsc.sig") ||
         APK.isArchiveRecordPresent("assets/__tpinfo.tsd") ||
         APK.isArchiveRecordPresent("assets/__tpinfo.tsd.sig") ||
         APK.isArchiveRecordPresent("assets/__tpcfinfo.tsa") ||
         APK.isArchiveRecordPresent("assets/__tpsinfo.t.p.sin") ||
-        APK.isArchiveRecordPresent("assets/tpginf.dat") ||
-        APK.isArchiveRecordPresent("lib/arm64-v8a/libtprt.so") ||
-        APK.isArchiveRecordPresent("lib/armeabi-v7a/libtprt.so") ||
-        APK.isArchiveRecordPresent("lib/armeabi/libtprt.so") ||
-        APK.isArchiveRecordPresent("lib/x86/libtprt.so") ||
-        APK.isArchiveRecordPresent("lib/arm64-v8a/libtersafe2.so") ||
-        APK.isArchiveRecordPresent("lib/armeabi-v7a/libtersafe2.so") ||
-        APK.isArchiveRecordPresent("lib/armeabi/libtersafe2.so") ||
-        APK.isArchiveRecordPresent("lib/x86/libtersafe2.so");
+        APK.isArchiveRecordPresent("assets/tpginf.dat")) {
+        bDetected = true;
+    } else if (APK.isArchiveRecordPresent("lib/arm64-v8a/libtprt.so")) {
+        sOptions = "arm64-v8a";
+        bDetected = true;
+    } else if (APK.isArchiveRecordPresent("lib/armeabi-v7a/libtprt.so")) {
+        sOptions = "armeabi-v7a";
+        bDetected = true;
+    } else if (APK.isArchiveRecordPresent("lib/armeabi/libtprt.so")) {
+        sOptions = "armeabi";
+        bDetected = true;
+    } else if (APK.isArchiveRecordPresent("lib/x86/libtprt.so")) {
+        sOptions = "x86";
+        bDetected = true;
+    } else if (APK.isArchiveRecordPresent("lib/arm64-v8a/libtersafe.so")) {
+        sOptions = "arm64-v8a";
+        bDetected = true;
+    } else if (APK.isArchiveRecordPresent("lib/armeabi-v7a/libtersafe.so")) {
+        sOptions = "armeabi-v7a";
+        bDetected = true;
+    } else if (APK.isArchiveRecordPresent("lib/armeabi/libtersafe.so")) {
+        sOptions = "armeabi";
+        bDetected = true;
+    } else if (APK.isArchiveRecordPresent("lib/x86/libtersafe.so")) {
+        sOptions = "x86";
+        bDetected = true;
+    }
 
     return result();
 }

--- a/db/DEX/protector_TPRT.2.sg
+++ b/db/DEX/protector_TPRT.2.sg
@@ -3,6 +3,7 @@
 // Author: Moli13337
 // GitHub: https://github.com/Moli13337
 // Reference: https://bbs.kanxue.com/thread-266762.htm
+
 meta("protector", "TPRT");
 
 function detect() {

--- a/db/DEX/protector_TPRT.2.sg
+++ b/db/DEX/protector_TPRT.2.sg
@@ -1,0 +1,15 @@
+// Detect It Easy: detection rule file
+
+// Author: Moli13337
+// GitHub: https://github.com/Moli13337
+
+meta("protector", "TPRT");
+
+function detect() {
+    bDetected =
+        DEX.isDexItemStringPresent("Lcom/ace/gshell/AceApplication;") ||
+        DEX.isDexItemStringPresent("libtprt") ||
+        DEX.isDexItemStringPresent("libtersafe2");
+
+    return result();
+}

--- a/db/DEX/protector_TPRT.2.sg
+++ b/db/DEX/protector_TPRT.2.sg
@@ -2,7 +2,7 @@
 
 // Author: Moli13337
 // GitHub: https://github.com/Moli13337
-
+// Reference: https://bbs.kanxue.com/thread-266762.htm
 meta("protector", "TPRT");
 
 function detect() {

--- a/db/DEX/protector_TPRT.2.sg
+++ b/db/DEX/protector_TPRT.2.sg
@@ -6,10 +6,7 @@
 meta("protector", "TPRT");
 
 function detect() {
-    bDetected =
-        DEX.isDexItemStringPresent("Lcom/ace/gshell/AceApplication;") ||
-        DEX.isDexItemStringPresent("libtprt") ||
-        DEX.isDexItemStringPresent("libtersafe2");
+    bDetected = DEX.isDexItemStringPresent("Lcom/ace/gshell/AceApplication;");
 
     return result();
 }


### PR DESCRIPTION
add tprt detection rule files

- ONLY add 2 .sg files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added detection support for applications protected with TPRT/Tencent protector technology.
  * Enhanced APK scanning by checking for common protector assets and native library indicators.
  * Improved accuracy with architecture-aware native library probing across multiple ABIs.
  * Added DEX bytecode detection targeting AceApplication-related markers to further strengthen identification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Samples

### APK Samples:
1. **王者荣耀**
   - Package: `com.tencent.tmgp.sgame`
   - Version: 11.3.1.1
   - Source: Tencent Games / Chinese App Store
   - Contains: `assets/__tpinfo.*` files + `lib/arm64-v8a/libtprt.so`

2. **辉烬**
   - Package: `com.bilibili.huijin`
   - Version: 1.6.0
   - Source: Bilibili Games
   - Contains: `assets/__tpinfo.*` files + `libtersafe2.so`

### DEX Samples:
- Both games contain `Lcom/ace/gshell/AceApplication;` in DEX strings
- Can be verified in any version of the mentioned games

### Raw APK download link: 
- com.tencent.tmgp.sgame: https://pvp.qq.com/
- com.bilibili.huijin: https://kiifstudio.com/